### PR TITLE
Update RecommendationProviderContainer.java

### DIFF
--- a/src/main/groovy/com/intershop/gradle/versionrecommender/recommendation/RecommendationProviderContainer.java
+++ b/src/main/groovy/com/intershop/gradle/versionrecommender/recommendation/RecommendationProviderContainer.java
@@ -85,7 +85,7 @@ public class RecommendationProviderContainer extends DefaultNamedDomainObjectLis
             localTask.setProvider(provider);
 
             // extend version of the provider with SNAPSHOT
-            SetLocalVersion snapshotTask = project.getTasks().create(provider.getTaskName("setSnapshot"), SetLocalVersion.class);
+            SetSnapshotVersion snapshotTask = project.getTasks().create(provider.getTaskName("setSnapshot"), SetSnapshotVersion.class);
             snapshotTask.setProvider(provider);
 
             // reset all temporary version configuration ot the provider


### PR DESCRIPTION
Task setSnapshot[provider] always appends the extension "LOCAL" instead of "SNAPHOT". It seems like the wrong task was configured in this class.

It would be great if you could fix that for v 1.x as well.